### PR TITLE
Update edition to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "job_scheduler"
 version = "1.2.1"
 authors = ["Lori Holden <noreply@loriholden.com>"]
 description = "A simple cron-like job scheduling library for Rust."
+edition = "2018"
 
 documentation = "https://docs.rs/job_scheduler/"
 repository = "https://github.com/lholden/job_scheduler"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ schedule of `0 0 6 * * Sun,Sat` would execute at 6am on Sunday and Saturday.
 A simple usage example:
 
 ```rust
-extern crate job_scheduler;
 use job_scheduler::{JobScheduler, Job};
 use std::time::Duration;
 

--- a/examples/simple_job.rs
+++ b/examples/simple_job.rs
@@ -1,5 +1,3 @@
-extern crate job_scheduler;
-
 use job_scheduler::{Job, JobScheduler};
 use std::time::Duration;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@
 //! A simple usage example:
 //!
 //! ```rust,ignore
-//! extern crate job_scheduler;
 //! use job_scheduler::{JobScheduler, Job};
 //! use std::time::Duration;
 //!
@@ -56,10 +55,6 @@
 //! }
 //! ```
 
-extern crate chrono;
-extern crate cron;
-extern crate uuid;
-
 use chrono::{offset, DateTime, Duration, Utc};
 pub use cron::Schedule;
 pub use uuid::Uuid;
@@ -67,7 +62,7 @@ pub use uuid::Uuid;
 /// A schedulable `Job`.
 pub struct Job<'a> {
     schedule: Schedule,
-    run: Box<(FnMut() -> ()) + 'a>,
+    run: Box<dyn (FnMut() -> ()) + 'a>,
     last_tick: Option<DateTime<Utc>>,
     limit_missed_runs: usize,
     job_id: Uuid,
@@ -213,7 +208,7 @@ impl<'a> JobScheduler<'a> {
     /// }
     /// ```
     pub fn tick(&mut self) {
-        for mut job in &mut self.jobs {
+        for job in &mut self.jobs {
             job.tick();
         }
     }


### PR DESCRIPTION
Update edition to 2018.

uuid v0.8 has MSRV of 1.32.0 ([ref](https://github.com/uuid-rs/uuid/blob/0.8.1/.travis.yml#L54-L58)).
So, job_scheduler user can use Edition 2018.