### PR TITLE
Push cron to 0.12, use "dyn" and remove "mut" from job iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ keywords = ["cron", "crontab", "scheduler", "job"]
 categories = ["date-and-time"]
 
 [dependencies]
-cron = "~0.6"
+cron = "~0.12"
 chrono = "~0.4"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub use uuid::Uuid;
 /// A schedulable `Job`.
 pub struct Job<'a> {
     schedule: Schedule,
-    run: Box<(FnMut() -> ()) + 'a>,
+    run: Box<dyn (FnMut() -> ()) + 'a>,
     last_tick: Option<DateTime<Utc>>,
     limit_missed_runs: usize,
     job_id: Uuid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ impl<'a> JobScheduler<'a> {
     /// }
     /// ```
     pub fn tick(&mut self) {
-        for mut job in &mut self.jobs {
+        for job in &mut self.jobs {
             job.tick();
         }
     }


### PR DESCRIPTION
Hi,

I branched and bumped cron to 0.12, it compiles.

Can you please check on your end and if possible include the version bump?

Cheers,
Thomas